### PR TITLE
Fix Window test path problem

### DIFF
--- a/test-runner/index.js
+++ b/test-runner/index.js
@@ -152,7 +152,7 @@ async function execJest(exercisePath, homeworkFolder) {
     const title = '*** Unit Test Error Report ***';
     console.log(chalk.yellow(`\n${title}\n`));
     console.log(verbose ? output : chalk.red(output));
-    message = stripAnsi(`${title}\n\n${output})`);
+    message = stripAnsi(`${title}\n\n${output}`);
     logger.error(message);
     return message;
   }

--- a/test-runner/index.js
+++ b/test-runner/index.js
@@ -125,7 +125,9 @@ async function execJest(exercisePath, homeworkFolder) {
 
   const { unitTestPath, verbose } = result;
 
-  let cmdLine = `npx jest "${unitTestPath}" --colors`;
+  const exerciseName = path.basename(unitTestPath);
+
+  let cmdLine = `npx jest ${exerciseName} --colors`;
 
   if (!verbose) {
     const customReporterPath = path.join(__dirname, 'CustomReporter.js');


### PR DESCRIPTION
This issue slipped in after adding unit testing in the exercises and occurred on Windows when used with Node 14 (no issue when used with Node 16). It is fixed by supplying just the (unique) exercise name (as was done previously) instead of the full path of the unit test file.