### PR TITLE
Add sysinfo.json to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea
+sysinfo.json
+
 # Logs
 logs
 npm-debug.log*


### PR DESCRIPTION
It is autogenerated during npm install and differs per device. It shouldn't be tracked by git